### PR TITLE
Adds support for separate credit / debit fees

### DIFF
--- a/client/common/CostSummary.js
+++ b/client/common/CostSummary.js
@@ -2,66 +2,179 @@
 
 import React from 'react';
 
-import { calculateCost, CERTIFICATE_COST_STRING } from '../../lib/costs';
+import {
+  calculateCreditCardCost,
+  calculateDebitCardCost,
+  CERTIFICATE_COST_STRING,
+} from '../../lib/costs';
 import type Cart from '../store/Cart';
+
+type ServiceFeeType = 'CREDIT' | 'DEBIT';
 
 type Props = {
   cart: Cart,
+  serviceFeeType: ServiceFeeType,
+  allowServiceFeeTypeChoice: boolean,
 };
 
-export default function CostSummary({ cart }: Props) {
-  const { total, subtotal, serviceFee } = calculateCost(cart.size);
+type State = {
+  serviceFeeType: ServiceFeeType,
+};
 
-  return (
-    <div className="m-v500">
-      <div className="p-v200">
-        <div className="cost-row">
-          <span className="t--info">
-            {cart.size} {cart.size === 1 ? 'certificate' : 'certificates'} ×{' '}
-            {CERTIFICATE_COST_STRING}
-          </span>
-          <span className="cost">${(subtotal / 100).toFixed(2)}</span>
+// Component to display the subtotal / service fee / shipping / total UI from
+// the cart and order review screens.
+export default class CostSummary extends React.Component<Props, State> {
+  static defaultProps = {
+    allowServiceFeeTypeChoice: false,
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      serviceFeeType: props.serviceFeeType,
+    };
+  }
+
+  handleCardOptionChanged = (ev: SyntheticInputEvent<*>) => {
+    this.setState({
+      serviceFeeType: (ev.target.value: any),
+    });
+  };
+
+  calculateCost() {
+    const { cart } = this.props;
+    const { serviceFeeType } = this.state;
+
+    return serviceFeeType === 'CREDIT'
+      ? calculateCreditCardCost(cart.size)
+      : calculateDebitCardCost(cart.size);
+  }
+
+  render() {
+    const { cart } = this.props;
+    const { total, subtotal } = this.calculateCost();
+
+    return (
+      <div className="m-v500">
+        <div className="p-v200">
+          <div className="cost-row">
+            <span className="t--info">
+              {cart.size} {cart.size === 1 ? 'certificate' : 'certificates'} ×{' '}
+              {CERTIFICATE_COST_STRING}
+            </span>
+            <span className="t--info cost">${(subtotal / 100).toFixed(2)}</span>
+          </div>
+
+          <div className="cost-row">{this.renderServiceFee()}</div>
+
+          <div className="cost-row">
+            <span className="t--info">Shipping within the U.S.</span>
+            <span className="t--info cost">
+              <i>included</i>
+            </span>
+          </div>
         </div>
 
         <div className="cost-row">
-          <a name="service-fee" />
-          <span className="t--info">
-            Credit card service fee <a href="#service-fee">*</a>
+          <span className="sh-title">Total</span>
+          <span className="cost br br-t100 p-v200">
+            ${(total / 100).toFixed(2)}
           </span>
-          <span className="cost">${(serviceFee / 100).toFixed(2)}</span>
         </div>
 
-        <div className="cost-row">
-          <span className="t--info">Shipping within the U.S.</span>
-          <span className="cost">
-            <i>included</i>
-          </span>
-        </div>
+        <style jsx>{`
+          .cost-row {
+            text-align: right;
+          }
+
+          .cost {
+            min-width: 5em;
+            margin-left: 1em;
+            display: inline-block;
+            color: #58585b;
+          }
+
+          .sh-title {
+            padding: 0;
+            line-height: 1;
+          }
+        `}</style>
       </div>
+    );
+  }
 
-      <div className="cost-row">
-        <span className="sh-title">Total</span>
-        <span className="cost br br-t100 p-v200">
-          ${(total / 100).toFixed(2)}
+  renderServiceFee() {
+    const { allowServiceFeeTypeChoice } = this.props;
+    const { serviceFeeType } = this.state;
+
+    let label;
+
+    if (allowServiceFeeTypeChoice) {
+      label = (
+        <span className="t--info" key="label">
+          <div className="sel sel--thin" style={{ display: 'inline-block' }}>
+            <div className="sel-c">
+              <select
+                id="serviceFeeTypeSelect"
+                className="sel-f"
+                onChange={this.handleCardOptionChanged}
+                value={serviceFeeType}
+              >
+                <option value="CREDIT">Credit card</option>
+                <option value="DEBIT">Debit card</option>
+              </select>
+            </div>
+          </div>{' '}
+          <label htmlFor="serviceFeeTypeSelect">
+            service fee
+            <a href="#service-fee">*</a>
+          </label>
+          <style jsx>{`
+            .sel--thin .sel-f {
+              padding-top: 0;
+              padding-bottom: 0;
+            }
+          `}</style>
         </span>
-      </div>
+      );
+    } else {
+      switch (serviceFeeType) {
+        case 'CREDIT':
+          label = (
+            <span className="t--info" key="label">
+              Credit card service fee <a href="#service-fee">*</a>
+            </span>
+          );
+          break;
 
-      <style jsx>{`
-        .cost-row {
-          text-align: right;
-        }
+        case 'DEBIT':
+          label = (
+            <span className="t--info" key="label">
+              Debit card service fee <a href="#service-fee">*</a>
+            </span>
+          );
+          break;
 
-        .cost {
-          min-width: 5em;
-          margin-left: 1em;
-          display: inline-block;
-        }
+        default:
+          throw new Error();
+      }
+    }
 
-        .sh-title {
-          padding: 0;
-          line-height: 1;
-        }
-      `}</style>
-    </div>
-  );
+    const { serviceFee } = this.calculateCost();
+
+    return [
+      label,
+      <span className="cost" key="value">
+        ${(serviceFee / 100).toFixed(2)}
+        <style jsx>{`
+          .cost {
+            min-width: 5em;
+            margin-left: 1em;
+            display: inline-block;
+          }
+        `}</style>
+      </span>,
+    ];
+  }
 }

--- a/client/common/CostSummary.stories.js
+++ b/client/common/CostSummary.stories.js
@@ -1,0 +1,46 @@
+// @flow
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Cart from '../store/Cart';
+
+import CostSummary from './CostSummary';
+
+import {
+  TYPICAL_CERTIFICATE,
+  PENDING_CERTIFICATE,
+  NO_DATE_CERTIFICATE,
+} from '../../fixtures/client/death-certificates';
+
+function makeCart() {
+  const cart = new Cart();
+
+  cart.add(TYPICAL_CERTIFICATE, 1);
+  cart.add(PENDING_CERTIFICATE, 3);
+  cart.add(NO_DATE_CERTIFICATE, 1);
+
+  return cart;
+}
+
+storiesOf('CostSummary', module)
+  .add('default credit card', () => (
+    <CostSummary
+      cart={makeCart()}
+      allowServiceFeeTypeChoice
+      serviceFeeType="CREDIT"
+    />
+  ))
+  .add('default debit card', () => (
+    <CostSummary
+      cart={makeCart()}
+      allowServiceFeeTypeChoice
+      serviceFeeType="DEBIT"
+    />
+  ))
+  .add('only credit card', () => (
+    <CostSummary cart={makeCart()} serviceFeeType="CREDIT" />
+  ))
+  .add('only debit card', () => (
+    <CostSummary cart={makeCart()} serviceFeeType="DEBIT" />
+  ));

--- a/client/dao/CheckoutDao.js
+++ b/client/dao/CheckoutDao.js
@@ -61,7 +61,8 @@ export default class CheckoutDao {
         const { card } = token;
 
         runInAction('CheckoutDao > tokenizeCard > createToken success', () => {
-          order.info.cardToken = token.id;
+          order.cardToken = token.id;
+          order.cardFunding = card.funding;
           order.info.cardLast4 = card.last4;
         });
 

--- a/client/dao/CheckoutDao.test.js
+++ b/client/dao/CheckoutDao.test.js
@@ -40,7 +40,9 @@ describe('tokenizeCard', () => {
 
   test('tokenization success path', async () => {
     stripe.createToken.mockReturnValue(
-      Promise.resolve({ token: { id: 'tok_id', card: { last4: '4040' } } })
+      Promise.resolve({
+        token: { id: 'tok_id', card: { last4: '4040', funding: 'debit' } },
+      })
     );
 
     const tokenizePromise = dao.tokenizeCard(order, cardElement);
@@ -49,7 +51,8 @@ describe('tokenizeCard', () => {
     const success = await tokenizePromise;
 
     expect(success).toEqual(true);
-    expect(order.info.cardToken).toEqual('tok_id');
+    expect(order.cardToken).toEqual('tok_id');
+    expect(order.cardFunding).toEqual('debit');
     expect(order.info.cardLast4).toEqual('4040');
     expect(order.processing).toEqual(false);
   });

--- a/client/death/cart/CartPage.js
+++ b/client/death/cart/CartPage.js
@@ -7,7 +7,7 @@ import Link from 'next/link';
 
 import { getDependencies } from '../../app';
 
-import { PERCENTAGE_STRING, FIXED_STRING } from '../../../lib/costs';
+import { PERCENTAGE_CC_STRING, FIXED_CC_STRING } from '../../../lib/costs';
 
 import type Cart from '../../store/Cart';
 
@@ -92,7 +92,11 @@ export class CartPageContent extends React.Component<Props> {
 
           {cart.entries.length > 0 && (
             <div className="p-a300">
-              <CostSummary cart={cart} />
+              <CostSummary
+                cart={cart}
+                allowServiceFeeTypeChoice
+                serviceFeeType="CREDIT"
+              />
 
               <div className="m-v500">
                 <Link href="/death/checkout">
@@ -108,15 +112,12 @@ export class CartPageContent extends React.Component<Props> {
 
               <p className="t--subinfo">
                 <a name="service-fee" />
-                * You are charged an extra service fee of {
-                  FIXED_STRING
-                } plus {PERCENTAGE_STRING}. This fee goes directly to a third
-                party to pay for the cost of credit card processing. Learn more
-                about{' '}
-                <a href="https://www.boston.gov/">
-                  credit card service fees
-                </a>{' '}
-                at the City of Boston.
+                * You are charged an extra service fee of no more than{' '}
+                {FIXED_CC_STRING} plus {PERCENTAGE_CC_STRING}. This fee goes
+                directly to a third party to pay for the cost of card
+                processing. Learn more about{' '}
+                <a href="https://www.boston.gov/">card service fees</a> at the
+                City of Boston.
               </p>
             </div>
           )}

--- a/client/death/certificate/CertificatePage.js
+++ b/client/death/certificate/CertificatePage.js
@@ -8,8 +8,8 @@ import type { DeathCertificate } from '../../types';
 
 import {
   CERTIFICATE_COST_STRING,
-  PERCENTAGE_STRING,
-  FIXED_STRING,
+  PERCENTAGE_CC_STRING,
+  FIXED_CC_STRING,
 } from '../../../lib/costs';
 
 import {
@@ -244,12 +244,12 @@ export class CertificatePageContent extends React.Component<
 
           <p className="t--subinfo">
             Death certificates cost {CERTIFICATE_COST_STRING} each. That price
-            includes shipping. You will be charged an extra service fee of{' '}
-            {FIXED_STRING} plus {PERCENTAGE_STRING}. That fee goes directly to a
-            third party to pay for the cost of credit card processing. Learn
-            more about{' '}
-            <a href="https://www.boston.gov/">credit card service fees</a> at
-            the City of Boston.
+            includes shipping. You will be charged an extra service fee of not
+            more than {FIXED_CC_STRING} plus {PERCENTAGE_CC_STRING}. That fee
+            goes directly to a third party to pay for the cost of card
+            processing. Learn more about{' '}
+            <a href="https://www.boston.gov/">card service fees</a> at the City
+            of Boston.
           </p>
         </div>
 

--- a/client/death/checkout/ConfirmationContent.js
+++ b/client/death/checkout/ConfirmationContent.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 import { observer } from 'mobx-react';
 
 export type Props = {|
@@ -42,6 +43,12 @@ export default class ConfirmationContent extends React.Component<Props> {
             <a href="tel:617-635-4175">617-635-4175</a> or email{' '}
             <a href="mailto:registry@boston.gov">registry@boston.gov</a>.
           </p>
+        </div>
+
+        <div className="m-v500 ta-c t--info">
+          <Link href="/death">
+            <a>Back to search</a>
+          </Link>
         </div>
       </div>
     );

--- a/client/death/checkout/OrderDetails.js
+++ b/client/death/checkout/OrderDetails.js
@@ -5,9 +5,9 @@ import Link from 'next/link';
 import VelocityTransitionGroup from 'velocity-react/velocity-transition-group';
 import {
   CERTIFICATE_COST_STRING,
-  PERCENTAGE_STRING,
-  FIXED_STRING,
-  calculateCost,
+  PERCENTAGE_CC_STRING,
+  FIXED_CC_STRING,
+  calculateCreditCardCost,
 } from '../../../lib/costs';
 
 import type Cart from '../../store/Cart';
@@ -105,7 +105,10 @@ export default class OrderDetails extends React.Component<Props, State> {
             <h2 className="stp">Order details</h2>
             <div className="t--info">
               {cart.size} {cart.size === 1 ? 'item' : 'items'} ×{' '}
-              {CERTIFICATE_COST_STRING} + service fee = ${(calculateCost(cart.size).total / 100).toFixed(2)}
+              {CERTIFICATE_COST_STRING} = ${(calculateCreditCardCost(cart.size)
+                .subtotal / 100
+              ).toFixed(2)}{' '}
+              + service fee*
             </div>
           </div>
         </button>
@@ -120,13 +123,12 @@ export default class OrderDetails extends React.Component<Props, State> {
               {this.renderCart(cart, false)}
 
               <p className="t--subinfo p-a300">
-                You are charged an extra service fee of {FIXED_STRING} plus{' '}
-                {PERCENTAGE_STRING}. This fee goes directly to a third party to
-                pay for the cost of credit card processing. Learn more about{' '}
-                <a href="https://www.boston.gov/">
-                  credit card service fees
-                </a>{' '}
-                at the City of Boston.
+                * You are charged an extra service fee of not more than{' '}
+                {FIXED_CC_STRING} plus {PERCENTAGE_CC_STRING}. This fee goes
+                directly to a third party to pay for the cost of card
+                processing. Learn more about{' '}
+                <a href="https://www.boston.gov/">card service fees</a> at the
+                City of Boston.
               </p>
 
               <div className="ta-c t--subinfo b--g">

--- a/client/death/checkout/PaymentContent.js
+++ b/client/death/checkout/PaymentContent.js
@@ -223,7 +223,7 @@ export default class PaymentContent extends React.Component<Props, State> {
 
               <div className="txt">
                 <label htmlFor="card-number" className="txt-l txt-l--mt000">
-                  Credit Card <span className="t--req">Required</span>
+                  Credit or Debit Card <span className="t--req">Required</span>
                 </label>
 
                 <div ref={this.setCardField} />
@@ -232,6 +232,10 @@ export default class PaymentContent extends React.Component<Props, State> {
                     {cardElementError}
                   </div>
                 )}
+
+                <div className="m-t100 t--subinfo">
+                  We accept Visa, MasterCard, and Discover.
+                </div>
               </div>
             </fieldset>
           </div>

--- a/client/death/checkout/PaymentContent.stories.js
+++ b/client/death/checkout/PaymentContent.stories.js
@@ -48,7 +48,6 @@ function makeShippingCompleteOrder(overrides = {}) {
     shippingZip: '12345',
 
     cardholderName: 'Nancy Whitehead',
-    cardToken: 'tok_testtoken',
     cardLast4: '4040',
 
     billingAddressSameAsShippingAddress: true,

--- a/client/death/checkout/ReviewContent.js
+++ b/client/death/checkout/ReviewContent.js
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { observer } from 'mobx-react';
 
-import { PERCENTAGE_STRING, FIXED_STRING } from '../../../lib/costs';
+import { PERCENTAGE_CC_STRING, FIXED_CC_STRING } from '../../../lib/costs';
 
 import type Cart from '../../store/Cart';
 import type Order from '../../models/Order';
@@ -49,6 +49,7 @@ export default class ReviewContent extends React.Component<Props> {
         cardholderName,
         cardLast4,
       },
+      cardFunding,
       billingAddress1,
       billingAddress2,
       billingCity,
@@ -139,7 +140,10 @@ export default class ReviewContent extends React.Component<Props> {
           </div>
 
           <div className="p-a300">
-            <CostSummary cart={cart} />
+            <CostSummary
+              cart={cart}
+              serviceFeeType={cardFunding === 'debit' ? 'DEBIT' : 'CREDIT'}
+            />
           </div>
 
           <div className="g p-a300">
@@ -151,9 +155,10 @@ export default class ReviewContent extends React.Component<Props> {
 
             <p className="g--9 t--subinfo">
               <a name="service-fee" />
-              * You are charged an extra service fee of {FIXED_STRING} plus{' '}
-              {PERCENTAGE_STRING}. This fee goes directly to a third party to
-              pay for the cost of credit card processing. Learn more about{' '}
+              * You are charged an extra service fee of not more than{' '}
+              {FIXED_CC_STRING} plus {PERCENTAGE_CC_STRING}. This fee goes
+              directly to a third party to pay for the cost of credit card
+              processing. Learn more about{' '}
               <a href="https://www.boston.gov/">credit card service fees</a> at
               the City of Boston.
             </p>

--- a/client/death/checkout/ReviewContent.stories.js
+++ b/client/death/checkout/ReviewContent.stories.js
@@ -45,7 +45,6 @@ function makeOrder(overrides = {}) {
     shippingZip: '12345',
 
     cardholderName: 'Nancy Whitehead',
-    cardToken: 'tok_testtoken',
     cardLast4: '4040',
 
     billingAddressSameAsShippingAddress: false,

--- a/client/death/checkout/ShippingContent.stories.js
+++ b/client/death/checkout/ShippingContent.stories.js
@@ -45,7 +45,6 @@ function makeOrder(overrides = {}) {
     shippingZip: '12345',
 
     cardholderName: 'Nancy Whitehead',
-    cardToken: 'tok_testtoken',
     cardLast4: '4040',
 
     billingAddressSameAsShippingAddress: true,

--- a/client/death/checkout/__snapshots__/CheckoutPage.test.js.snap
+++ b/client/death/checkout/__snapshots__/CheckoutPage.test.js.snap
@@ -25,6 +25,8 @@ exports[`integration renders payment 1`] = `
       Order {
         "cardElementComplete": false,
         "cardElementError": null,
+        "cardFunding": "credit",
+        "cardToken": null,
         "info": Object {
           "billingAddress1": "",
           "billingAddress2": "",
@@ -32,8 +34,7 @@ exports[`integration renders payment 1`] = `
           "billingCity": "",
           "billingState": "",
           "billingZip": "",
-          "cardLast4": null,
-          "cardToken": null,
+          "cardLast4": "",
           "cardholderName": "",
           "contactEmail": "",
           "contactName": "",
@@ -69,6 +70,8 @@ exports[`integration renders shipping 1`] = `
       Order {
         "cardElementComplete": false,
         "cardElementError": null,
+        "cardFunding": "credit",
+        "cardToken": null,
         "info": Object {
           "billingAddress1": "",
           "billingAddress2": "",
@@ -76,8 +79,7 @@ exports[`integration renders shipping 1`] = `
           "billingCity": "",
           "billingState": "",
           "billingZip": "",
-          "cardLast4": null,
-          "cardToken": null,
+          "cardLast4": "",
           "cardholderName": "",
           "contactEmail": "",
           "contactName": "",

--- a/client/models/Order.js
+++ b/client/models/Order.js
@@ -27,8 +27,7 @@ export type OrderInfo = {|
   shippingZip: string,
 
   cardholderName: string,
-  cardToken: ?string,
-  cardLast4: ?string,
+  cardLast4: string,
 
   billingAddressSameAsShippingAddress: boolean,
 
@@ -41,6 +40,10 @@ export type OrderInfo = {|
 
 export default class Order {
   @observable info: OrderInfo;
+
+  @observable cardToken: ?string = null;
+  @observable
+  cardFunding: 'credit' | 'debit' | 'prepaid' | 'unknown' = 'credit';
 
   @observable cardElementError: ?string = null;
   @observable cardElementComplete: boolean = false;
@@ -74,8 +77,7 @@ export default class Order {
       shippingZip: '',
 
       cardholderName: '',
-      cardToken: null,
-      cardLast4: null,
+      cardLast4: '',
 
       billingAddressSameAsShippingAddress: true,
 

--- a/client/queries/submit-death-certificate-order.js
+++ b/client/queries/submit-death-certificate-order.js
@@ -16,34 +16,33 @@ export default async function submitDeathCertificateOrder(
   order: Order
 ): Promise<string> {
   const {
-    contactName,
-    contactEmail,
-    contactPhone,
-    shippingName,
-    shippingCompanyName,
-    shippingAddress1,
-    shippingAddress2,
-    shippingCity,
-    shippingState,
-    shippingZip,
-    cardholderName,
+    info: {
+      contactName,
+      contactEmail,
+      contactPhone,
+      shippingName,
+      shippingCompanyName,
+      shippingAddress1,
+      shippingAddress2,
+      shippingCity,
+      shippingState,
+      shippingZip,
+      cardholderName,
+      cardLast4,
+    },
     cardToken,
-    cardLast4,
-  } = order.info;
-
-  if (!cardToken || !cardLast4) {
-    throw new Error(
-      'submitDeathCertificateOrder called before card tokenization'
-    );
-  }
-
-  const {
     billingAddress1,
     billingAddress2,
     billingCity,
     billingState,
     billingZip,
   } = order;
+
+  if (!cardToken || !cardLast4) {
+    throw new Error(
+      'submitDeathCertificateOrder called before card tokenization'
+    );
+  }
 
   const queryVariables: SubmitDeathCertificateOrderMutationVariables = {
     contactName,

--- a/client/queries/submit-death-certificate-order.test.js
+++ b/client/queries/submit-death-certificate-order.test.js
@@ -39,7 +39,6 @@ test('submitDeathCertificateOrder', async () => {
     shippingZip: '12345',
 
     cardholderName: 'Nancy Whitehead',
-    cardToken: 'tok_testtoken',
     cardLast4: '4040',
 
     billingAddressSameAsShippingAddress: false,
@@ -50,6 +49,8 @@ test('submitDeathCertificateOrder', async () => {
     billingState: 'NY',
     billingZip: '12223',
   };
+
+  order.cardToken = 'tok_testtoken';
 
   await submitDeathCertificateOrder(loopbackGraphql, cart, order);
 

--- a/client/store/Cart.js
+++ b/client/store/Cart.js
@@ -81,7 +81,11 @@ export default class Cart {
 
   @computed
   get size(): number {
-    return this.entries.reduce((acc, item) => acc + item.quantity, 0);
+    // quantity shouldn't be below 0 but we want to be defensive.
+    return this.entries.reduce(
+      (acc, item) => acc + Math.max(item.quantity, 0),
+      0
+    );
   }
 
   @computed

--- a/client/store/OrderProvider.js
+++ b/client/store/OrderProvider.js
@@ -76,7 +76,6 @@ export default class OrderProvider {
 
       // not stored
       cardholderName: '',
-      cardToken: 'tok_testtoken',
       cardLast4: '4040',
 
       billingAddressSameAsShippingAddress: storeBilling

--- a/client/store/OrderProvider.test.js
+++ b/client/store/OrderProvider.test.js
@@ -49,7 +49,6 @@ describe('storage', () => {
           shippingZip: '12345',
 
           cardholderName: '',
-          cardToken: 'tok_testtoken',
           cardLast4: '4040',
 
           billingAddressSameAsShippingAddress: true,

--- a/flow-typed/npm/stripe_vx.x.x.js
+++ b/flow-typed/npm/stripe_vx.x.x.js
@@ -103,6 +103,40 @@ declare module 'stripe' {
     statement_description?: ?string,
   |};
 
+  declare export type Token = {|
+    id: string,
+    object: 'token',
+    card: {
+      id: string,
+      object: 'card',
+      address_city: ?string,
+      address_country: ?string,
+      address_line1: ?string,
+      address_line1_check: ?StripeCheckResult,
+      address_line2: ?string,
+      address_state: ?string,
+      address_zip: ?string,
+      address_zip_check: ?StripeCheckResult,
+      brand: string,
+      country: string,
+      cvc_check: ?StripeCheckResult,
+      dynamic_last4: ?string,
+      exp_month: number,
+      exp_year: number,
+      fingerprint: string,
+      funding: 'credit' | 'debit' | 'prepaid' | 'unknown',
+      last4: string,
+      metadata: { [key: string]: string },
+      name: ?string,
+      tokenization_method: 'apple_pay' | 'android_pay' | null,
+    },
+    client_ip: ?string,
+    created: number,
+    livemode: boolean,
+    type: 'card' | 'bank_account',
+    used: boolean,
+  |};
+
   declare export type Card = {|
     id: string,
     object: 'card',
@@ -220,7 +254,14 @@ declare module 'stripe' {
         charge: ChargeInput,
         cb?: (err: Error, charge: Charge) => mixed
       ) => Promise<Charge>,
-    |}
+    |},
+
+    tokens: {|
+      retrieve: (
+        id: string,
+        cb?: (err: Error, token: Token) => mixed
+      ) => Promise<Token>,
+    |},
   |};
 
   declare export default (secretKey: string) => NodeStripe;

--- a/lib/costs.js
+++ b/lib/costs.js
@@ -1,27 +1,55 @@
 // @flow
 
+// All costs are in cents, which is how Stripe does things.
+
 export const CERTIFICATE_COST = 14 * 100;
-export const FIXED_SERVICE_FEE = 25;
-export const PERCENTAGE_SERVICE_FEE = 0.021;
+
+// CC == "credit card"
+export const FIXED_CC_SERVICE_FEE = 25;
+export const PERCENTAGE_CC_SERVICE_FEE = 0.021;
+
+// DC == "debit card"
+export const FIXED_DC_SERVICE_FEE = 25;
+export const PERCENTAGE_DC_SERVICE_FEE = 0.015;
 
 // Used to describe the percentage when you have to take into account your own
 // percentage.
-const PERCENT_OF_TOTAL = 1 / (1 - PERCENTAGE_SERVICE_FEE) - 1;
+const CC_PERCENT_OF_TOTAL = 1 / (1 - PERCENTAGE_CC_SERVICE_FEE) - 1;
 
 export const CERTIFICATE_COST_STRING = `$${(CERTIFICATE_COST / 100).toFixed(
   2
 )}`;
-export const PERCENTAGE_STRING = `${(Math.round(PERCENT_OF_TOTAL * 10000) / 100
+export const PERCENTAGE_CC_STRING = `${(Math.round(
+  CC_PERCENT_OF_TOTAL * 10000
+) / 100
 ).toFixed(2)}%`;
-export const FIXED_STRING = `$${(FIXED_SERVICE_FEE / 100).toFixed(2)}`;
+export const FIXED_CC_STRING = `$${(FIXED_CC_SERVICE_FEE / 100).toFixed(2)}`;
 
-export function calculateCost(quantity: number) {
+export function calculateCreditCardCost(quantity: number) {
+  return calculateCost(
+    quantity,
+    FIXED_CC_SERVICE_FEE,
+    PERCENTAGE_CC_SERVICE_FEE
+  );
+}
+
+export function calculateDebitCardCost(quantity: number) {
+  return calculateCost(
+    quantity,
+    FIXED_DC_SERVICE_FEE,
+    PERCENTAGE_DC_SERVICE_FEE
+  );
+}
+
+export function calculateCost(
+  quantity: number,
+  fixedCost: number,
+  percentageCost: number
+) {
   const subtotal = quantity * CERTIFICATE_COST;
 
   // Math: https://support.stripe.com/questions/can-i-charge-my-stripe-fees-to-my-customers
-  const total = Math.round(
-    (subtotal + FIXED_SERVICE_FEE) / (1 - PERCENTAGE_SERVICE_FEE)
-  );
+  const total = Math.round((subtotal + fixedCost) / (1 - percentageCost));
 
   const serviceFee = total - subtotal;
 

--- a/lib/costs.test.js
+++ b/lib/costs.test.js
@@ -1,9 +1,9 @@
 // @flow
 
 import {
-  FIXED_SERVICE_FEE,
-  PERCENTAGE_SERVICE_FEE,
-  calculateCost,
+  FIXED_CC_SERVICE_FEE,
+  PERCENTAGE_CC_SERVICE_FEE,
+  calculateCreditCardCost,
 } from './costs';
 
 // We run this over a bunch of different amounts to verify that, after rounding
@@ -11,11 +11,11 @@ import {
 // with the right certificate cost for Registry.
 it(`calculates service fee correctly for certificates`, () => {
   for (let q = 1; q < 100; ++q) {
-    const { total, serviceFee, subtotal } = calculateCost(q);
+    const { total, serviceFee, subtotal } = calculateCreditCardCost(q);
 
     // Stripe rounding: https://support.stripe.com/questions/what-rules-do-you-use-for-rounding-stripe-fees
     const stripesCut = Math.round(
-      total * PERCENTAGE_SERVICE_FEE + FIXED_SERVICE_FEE
+      total * PERCENTAGE_CC_SERVICE_FEE + FIXED_CC_SERVICE_FEE
     );
 
     expect(stripesCut).toEqual(serviceFee);

--- a/server/graphql/mutation.test.js
+++ b/server/graphql/mutation.test.js
@@ -50,13 +50,21 @@ describe('Mutation resolvers', () => {
     });
 
     it('sends a charge to Stripe', async () => {
+      const tokensRetrieve = jest.fn();
       const chargesCreate = jest.fn();
+
       const stripe: any = {
         charges: {
           create: chargesCreate,
         },
+        tokens: {
+          retrieve: tokensRetrieve,
+        },
       };
 
+      tokensRetrieve.mockReturnValue(
+        Promise.resolve({ card: { funding: 'credit' } })
+      );
       chargesCreate.mockReturnValue(Promise.resolve({ id: 'ch_12345' }));
 
       await resolvers.Mutation.submitDeathCertificateOrder(

--- a/storybook/__snapshots__/Storyshots.test.js.snap
+++ b/storybook/__snapshots__/Storyshots.test.js.snap
@@ -1034,16 +1034,16 @@ exports[`Storyshots CartPage loading 1`] = `
           className="jsx-858389963 p-a300"
         >
           <div
-            className="jsx-4282255710 m-v500"
+            className="jsx-2514143691 m-v500"
           >
             <div
-              className="jsx-4282255710 p-v200"
+              className="jsx-2514143691 p-v200"
             >
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   8
                    
@@ -1053,50 +1053,84 @@ exports[`Storyshots CartPage loading 1`] = `
                   $14.00
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   $
                   112.00
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
-                <a
-                  className="jsx-4282255710"
-                  name="service-fee"
-                />
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-443563205 t--info"
                 >
-                  Credit card service fee 
-                  <a
-                    className="jsx-4282255710"
-                    href="#service-fee"
+                  <div
+                    className="jsx-443563205 sel sel--thin"
+                    style={
+                      Object {
+                        "display": "inline-block",
+                      }
+                    }
                   >
-                    *
-                  </a>
+                    <div
+                      className="jsx-443563205 sel-c"
+                    >
+                      <select
+                        className="jsx-443563205 sel-f"
+                        id="serviceFeeTypeSelect"
+                        onChange={[Function]}
+                        value="CREDIT"
+                      >
+                        <option
+                          className="jsx-443563205"
+                          value="CREDIT"
+                        >
+                          Credit card
+                        </option>
+                        <option
+                          className="jsx-443563205"
+                          value="DEBIT"
+                        >
+                          Debit card
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                   
+                  <label
+                    className="jsx-443563205"
+                    htmlFor="serviceFeeTypeSelect"
+                  >
+                    service fee
+                    <a
+                      className="jsx-443563205"
+                      href="#service-fee"
+                    >
+                      *
+                    </a>
+                  </label>
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2394436591 cost"
                 >
                   $
                   2.66
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   Shipping within the U.S.
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   <i
-                    className="jsx-4282255710"
+                    className="jsx-2514143691"
                   >
                     included
                   </i>
@@ -1104,15 +1138,15 @@ exports[`Storyshots CartPage loading 1`] = `
               </div>
             </div>
             <div
-              className="jsx-4282255710 cost-row"
+              className="jsx-2514143691 cost-row"
             >
               <span
-                className="jsx-4282255710 sh-title"
+                className="jsx-2514143691 sh-title"
               >
                 Total
               </span>
               <span
-                className="jsx-4282255710 cost br br-t100 p-v200"
+                className="jsx-2514143691 cost br br-t100 p-v200"
               >
                 $
                 114.66
@@ -1148,20 +1182,20 @@ exports[`Storyshots CartPage loading 1`] = `
               className="jsx-858389963"
               name="service-fee"
             />
-            * You are charged an extra service fee of 
+            * You are charged an extra service fee of no more than
+             
             $0.25
              plus 
             2.15%
-            . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+            . This fee goes directly to a third party to pay for the cost of card processing. Learn more about
              
             <a
               className="jsx-858389963"
               href="https://www.boston.gov/"
             >
-              credit card service fees
+              card service fees
             </a>
-             
-            at the City of Boston.
+             at the City of Boston.
           </p>
         </div>
       </div>
@@ -1707,16 +1741,16 @@ exports[`Storyshots CartPage normal page 1`] = `
           className="jsx-858389963 p-a300"
         >
           <div
-            className="jsx-4282255710 m-v500"
+            className="jsx-2514143691 m-v500"
           >
             <div
-              className="jsx-4282255710 p-v200"
+              className="jsx-2514143691 p-v200"
             >
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   5
                    
@@ -1726,50 +1760,84 @@ exports[`Storyshots CartPage normal page 1`] = `
                   $14.00
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   $
                   70.00
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
-                <a
-                  className="jsx-4282255710"
-                  name="service-fee"
-                />
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-443563205 t--info"
                 >
-                  Credit card service fee 
-                  <a
-                    className="jsx-4282255710"
-                    href="#service-fee"
+                  <div
+                    className="jsx-443563205 sel sel--thin"
+                    style={
+                      Object {
+                        "display": "inline-block",
+                      }
+                    }
                   >
-                    *
-                  </a>
+                    <div
+                      className="jsx-443563205 sel-c"
+                    >
+                      <select
+                        className="jsx-443563205 sel-f"
+                        id="serviceFeeTypeSelect"
+                        onChange={[Function]}
+                        value="CREDIT"
+                      >
+                        <option
+                          className="jsx-443563205"
+                          value="CREDIT"
+                        >
+                          Credit card
+                        </option>
+                        <option
+                          className="jsx-443563205"
+                          value="DEBIT"
+                        >
+                          Debit card
+                        </option>
+                      </select>
+                    </div>
+                  </div>
+                   
+                  <label
+                    className="jsx-443563205"
+                    htmlFor="serviceFeeTypeSelect"
+                  >
+                    service fee
+                    <a
+                      className="jsx-443563205"
+                      href="#service-fee"
+                    >
+                      *
+                    </a>
+                  </label>
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2394436591 cost"
                 >
                   $
                   1.76
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   Shipping within the U.S.
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   <i
-                    className="jsx-4282255710"
+                    className="jsx-2514143691"
                   >
                     included
                   </i>
@@ -1777,15 +1845,15 @@ exports[`Storyshots CartPage normal page 1`] = `
               </div>
             </div>
             <div
-              className="jsx-4282255710 cost-row"
+              className="jsx-2514143691 cost-row"
             >
               <span
-                className="jsx-4282255710 sh-title"
+                className="jsx-2514143691 sh-title"
               >
                 Total
               </span>
               <span
-                className="jsx-4282255710 cost br br-t100 p-v200"
+                className="jsx-2514143691 cost br br-t100 p-v200"
               >
                 $
                 71.76
@@ -1821,20 +1889,20 @@ exports[`Storyshots CartPage normal page 1`] = `
               className="jsx-858389963"
               name="service-fee"
             />
-            * You are charged an extra service fee of 
+            * You are charged an extra service fee of no more than
+             
             $0.25
              plus 
             2.15%
-            . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+            . This fee goes directly to a third party to pay for the cost of card processing. Learn more about
              
             <a
               className="jsx-858389963"
               href="https://www.boston.gov/"
             >
-              credit card service fees
+              card service fees
             </a>
-             
-            at the City of Boston.
+             at the City of Boston.
           </p>
         </div>
       </div>
@@ -2888,18 +2956,17 @@ exports[`Storyshots CertificatePage normal certificate 1`] = `
             >
               Death certificates cost 
               $14.00
-               each. That price includes shipping. You will be charged an extra service fee of
-               
+               each. That price includes shipping. You will be charged an extra service fee of not more than 
               $0.25
                plus 
               2.15%
-              . That fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+              . That fee goes directly to a third party to pay for the cost of card processing. Learn more about
                
               <a
                 className="jsx-3528172379"
                 href="https://www.boston.gov/"
               >
-                credit card service fees
+                card service fees
               </a>
                at the City of Boston.
             </p>
@@ -3536,18 +3603,17 @@ exports[`Storyshots CertificatePage normal certificate — added to cart 1`] = `
             >
               Death certificates cost 
               $14.00
-               each. That price includes shipping. You will be charged an extra service fee of
-               
+               each. That price includes shipping. You will be charged an extra service fee of not more than 
               $0.25
                plus 
               2.15%
-              . That fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+              . That fee goes directly to a third party to pay for the cost of card processing. Learn more about
                
               <a
                 className="jsx-3528172379"
                 href="https://www.boston.gov/"
               >
-                credit card service fees
+                card service fees
               </a>
                at the City of Boston.
             </p>
@@ -4246,18 +4312,17 @@ exports[`Storyshots CertificatePage normal certificate — not from search 1`] =
             >
               Death certificates cost 
               $14.00
-               each. That price includes shipping. You will be charged an extra service fee of
-               
+               each. That price includes shipping. You will be charged an extra service fee of not more than 
               $0.25
                plus 
               2.15%
-              . That fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+              . That fee goes directly to a third party to pay for the cost of card processing. Learn more about
                
               <a
                 className="jsx-3528172379"
                 href="https://www.boston.gov/"
               >
-                credit card service fees
+                card service fees
               </a>
                at the City of Boston.
             </p>
@@ -4880,18 +4945,17 @@ exports[`Storyshots CertificatePage pending certificate 1`] = `
             >
               Death certificates cost 
               $14.00
-               each. That price includes shipping. You will be charged an extra service fee of
-               
+               each. That price includes shipping. You will be charged an extra service fee of not more than 
               $0.25
                plus 
               2.15%
-              . That fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+              . That fee goes directly to a third party to pay for the cost of card processing. Learn more about
                
               <a
                 className="jsx-3528172379"
                 href="https://www.boston.gov/"
               >
-                credit card service fees
+                card service fees
               </a>
                at the City of Boston.
             </p>
@@ -5329,6 +5393,16 @@ exports[`Storyshots ConfirmationContent default 1`] = `
           .
         </p>
       </div>
+      <div
+        className="m-v500 ta-c t--info"
+      >
+        <a
+          href="/death"
+          onClick={[Function]}
+        >
+          Back to search
+        </a>
+      </div>
     </div>
   </div>
   <footer
@@ -5357,6 +5431,420 @@ exports[`Storyshots ConfirmationContent default 1`] = `
       }
     }
   />
+</div>
+`;
+
+exports[`Storyshots CostSummary default credit card 1`] = `
+<div
+  className="jsx-2514143691 m-v500"
+>
+  <div
+    className="jsx-2514143691 p-v200"
+  >
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        5
+         
+        certificates
+         ×
+         
+        $14.00
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        $
+        70.00
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-443563205 t--info"
+      >
+        <div
+          className="jsx-443563205 sel sel--thin"
+          style={
+            Object {
+              "display": "inline-block",
+            }
+          }
+        >
+          <div
+            className="jsx-443563205 sel-c"
+          >
+            <select
+              className="jsx-443563205 sel-f"
+              id="serviceFeeTypeSelect"
+              onChange={[Function]}
+              value="CREDIT"
+            >
+              <option
+                className="jsx-443563205"
+                value="CREDIT"
+              >
+                Credit card
+              </option>
+              <option
+                className="jsx-443563205"
+                value="DEBIT"
+              >
+                Debit card
+              </option>
+            </select>
+          </div>
+        </div>
+         
+        <label
+          className="jsx-443563205"
+          htmlFor="serviceFeeTypeSelect"
+        >
+          service fee
+          <a
+            className="jsx-443563205"
+            href="#service-fee"
+          >
+            *
+          </a>
+        </label>
+      </span>
+      <span
+        className="jsx-2394436591 cost"
+      >
+        $
+        1.76
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        Shipping within the U.S.
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        <i
+          className="jsx-2514143691"
+        >
+          included
+        </i>
+      </span>
+    </div>
+  </div>
+  <div
+    className="jsx-2514143691 cost-row"
+  >
+    <span
+      className="jsx-2514143691 sh-title"
+    >
+      Total
+    </span>
+    <span
+      className="jsx-2514143691 cost br br-t100 p-v200"
+    >
+      $
+      71.76
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Storyshots CostSummary default debit card 1`] = `
+<div
+  className="jsx-2514143691 m-v500"
+>
+  <div
+    className="jsx-2514143691 p-v200"
+  >
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        5
+         
+        certificates
+         ×
+         
+        $14.00
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        $
+        70.00
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-443563205 t--info"
+      >
+        <div
+          className="jsx-443563205 sel sel--thin"
+          style={
+            Object {
+              "display": "inline-block",
+            }
+          }
+        >
+          <div
+            className="jsx-443563205 sel-c"
+          >
+            <select
+              className="jsx-443563205 sel-f"
+              id="serviceFeeTypeSelect"
+              onChange={[Function]}
+              value="DEBIT"
+            >
+              <option
+                className="jsx-443563205"
+                value="CREDIT"
+              >
+                Credit card
+              </option>
+              <option
+                className="jsx-443563205"
+                value="DEBIT"
+              >
+                Debit card
+              </option>
+            </select>
+          </div>
+        </div>
+         
+        <label
+          className="jsx-443563205"
+          htmlFor="serviceFeeTypeSelect"
+        >
+          service fee
+          <a
+            className="jsx-443563205"
+            href="#service-fee"
+          >
+            *
+          </a>
+        </label>
+      </span>
+      <span
+        className="jsx-2394436591 cost"
+      >
+        $
+        1.32
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        Shipping within the U.S.
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        <i
+          className="jsx-2514143691"
+        >
+          included
+        </i>
+      </span>
+    </div>
+  </div>
+  <div
+    className="jsx-2514143691 cost-row"
+  >
+    <span
+      className="jsx-2514143691 sh-title"
+    >
+      Total
+    </span>
+    <span
+      className="jsx-2514143691 cost br br-t100 p-v200"
+    >
+      $
+      71.32
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Storyshots CostSummary only credit card 1`] = `
+<div
+  className="jsx-2514143691 m-v500"
+>
+  <div
+    className="jsx-2514143691 p-v200"
+  >
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        5
+         
+        certificates
+         ×
+         
+        $14.00
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        $
+        70.00
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="t--info"
+      >
+        Credit card service fee 
+        <a
+          href="#service-fee"
+        >
+          *
+        </a>
+      </span>
+      <span
+        className="jsx-2394436591 cost"
+      >
+        $
+        1.76
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        Shipping within the U.S.
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        <i
+          className="jsx-2514143691"
+        >
+          included
+        </i>
+      </span>
+    </div>
+  </div>
+  <div
+    className="jsx-2514143691 cost-row"
+  >
+    <span
+      className="jsx-2514143691 sh-title"
+    >
+      Total
+    </span>
+    <span
+      className="jsx-2514143691 cost br br-t100 p-v200"
+    >
+      $
+      71.76
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Storyshots CostSummary only debit card 1`] = `
+<div
+  className="jsx-2514143691 m-v500"
+>
+  <div
+    className="jsx-2514143691 p-v200"
+  >
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        5
+         
+        certificates
+         ×
+         
+        $14.00
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        $
+        70.00
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="t--info"
+      >
+        Debit card service fee 
+        <a
+          href="#service-fee"
+        >
+          *
+        </a>
+      </span>
+      <span
+        className="jsx-2394436591 cost"
+      >
+        $
+        1.32
+      </span>
+    </div>
+    <div
+      className="jsx-2514143691 cost-row"
+    >
+      <span
+        className="jsx-2514143691 t--info"
+      >
+        Shipping within the U.S.
+      </span>
+      <span
+        className="jsx-2514143691 t--info cost"
+      >
+        <i
+          className="jsx-2514143691"
+        >
+          included
+        </i>
+      </span>
+    </div>
+  </div>
+  <div
+    className="jsx-2514143691 cost-row"
+  >
+    <span
+      className="jsx-2514143691 sh-title"
+    >
+      Total
+    </span>
+    <span
+      className="jsx-2514143691 cost br br-t100 p-v200"
+    >
+      $
+      71.32
+    </span>
+  </div>
 </div>
 `;
 
@@ -5426,8 +5914,10 @@ exports[`Storyshots OrderDetails closed 1`] = `
          ×
          
         $14.00
-         + service fee = $
-        71.76
+         = $
+        70.00
+         
+        + service fee*
       </div>
     </div>
   </button>
@@ -5656,8 +6146,10 @@ exports[`Storyshots OrderDetails loading 1`] = `
          ×
          
         $14.00
-         + service fee = $
-        114.66
+         = $
+        112.00
+         
+        + service fee*
       </div>
     </div>
   </button>
@@ -5708,8 +6200,10 @@ exports[`Storyshots OrderDetails open 1`] = `
          ×
          
         $14.00
-         + service fee = $
-        71.76
+         = $
+        70.00
+         
+        + service fee*
       </div>
     </div>
   </button>
@@ -5841,21 +6335,20 @@ exports[`Storyshots OrderDetails open 1`] = `
       <p
         className="jsx-3101717291 t--subinfo p-a300"
       >
-        You are charged an extra service fee of 
-        $0.25
-         plus
+        * You are charged an extra service fee of not more than
          
+        $0.25
+         plus 
         2.15%
-        . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
+        . This fee goes directly to a third party to pay for the cost of card processing. Learn more about
          
         <a
           className="jsx-3101717291"
           href="https://www.boston.gov/"
         >
-          credit card service fees
+          card service fees
         </a>
-         
-        at the City of Boston.
+         at the City of Boston.
       </p>
       <div
         className="jsx-3101717291 ta-c t--subinfo b--g"
@@ -6456,8 +6949,10 @@ exports[`Storyshots PaymentContent Stripe error 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -6552,7 +7047,7 @@ exports[`Storyshots PaymentContent Stripe error 1`] = `
                 className="jsx-418405546 txt-l txt-l--mt000"
                 htmlFor="card-number"
               >
-                Credit Card 
+                Credit or Debit Card 
                 <span
                   className="jsx-418405546 t--req"
                 >
@@ -6562,6 +7057,11 @@ exports[`Storyshots PaymentContent Stripe error 1`] = `
               <div
                 className="jsx-418405546"
               />
+              <div
+                className="jsx-418405546 m-t100 t--subinfo"
+              >
+                We accept Visa, MasterCard, and Discover.
+              </div>
             </div>
           </fieldset>
         </div>
@@ -7224,8 +7724,10 @@ exports[`Storyshots PaymentContent credit card error 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -7320,7 +7822,7 @@ exports[`Storyshots PaymentContent credit card error 1`] = `
                 className="jsx-418405546 txt-l txt-l--mt000"
                 htmlFor="card-number"
               >
-                Credit Card 
+                Credit or Debit Card 
                 <span
                   className="jsx-418405546 t--req"
                 >
@@ -7334,6 +7836,11 @@ exports[`Storyshots PaymentContent credit card error 1`] = `
                 className="jsx-418405546 t--subinfo t--err m-t100"
               >
                 Your card number is incomplete.
+              </div>
+              <div
+                className="jsx-418405546 m-t100 t--subinfo"
+              >
+                We accept Visa, MasterCard, and Discover.
               </div>
             </div>
           </fieldset>
@@ -7991,8 +8498,10 @@ exports[`Storyshots PaymentContent default 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -8087,7 +8596,7 @@ exports[`Storyshots PaymentContent default 1`] = `
                 className="jsx-418405546 txt-l txt-l--mt000"
                 htmlFor="card-number"
               >
-                Credit Card 
+                Credit or Debit Card 
                 <span
                   className="jsx-418405546 t--req"
                 >
@@ -8097,6 +8606,11 @@ exports[`Storyshots PaymentContent default 1`] = `
               <div
                 className="jsx-418405546"
               />
+              <div
+                className="jsx-418405546 m-t100 t--subinfo"
+              >
+                We accept Visa, MasterCard, and Discover.
+              </div>
             </div>
           </fieldset>
         </div>
@@ -8606,8 +9120,10 @@ exports[`Storyshots PaymentContent existing billing 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -8702,7 +9218,7 @@ exports[`Storyshots PaymentContent existing billing 1`] = `
                 className="jsx-418405546 txt-l txt-l--mt000"
                 htmlFor="card-number"
               >
-                Credit Card 
+                Credit or Debit Card 
                 <span
                   className="jsx-418405546 t--req"
                 >
@@ -8712,6 +9228,11 @@ exports[`Storyshots PaymentContent existing billing 1`] = `
               <div
                 className="jsx-418405546"
               />
+              <div
+                className="jsx-418405546 m-t100 t--subinfo"
+              >
+                We accept Visa, MasterCard, and Discover.
+              </div>
             </div>
           </fieldset>
         </div>
@@ -9368,8 +9889,10 @@ exports[`Storyshots PaymentContent state error 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -9464,7 +9987,7 @@ exports[`Storyshots PaymentContent state error 1`] = `
                 className="jsx-418405546 txt-l txt-l--mt000"
                 htmlFor="card-number"
               >
-                Credit Card 
+                Credit or Debit Card 
                 <span
                   className="jsx-418405546 t--req"
                 >
@@ -9474,6 +9997,11 @@ exports[`Storyshots PaymentContent state error 1`] = `
               <div
                 className="jsx-418405546"
               />
+              <div
+                className="jsx-418405546 m-t100 t--subinfo"
+              >
+                We accept Visa, MasterCard, and Discover.
+              </div>
             </div>
           </fieldset>
         </div>
@@ -10408,16 +10936,16 @@ exports[`Storyshots ReviewContent default 1`] = `
           className="jsx-2133745651 p-a300"
         >
           <div
-            className="jsx-4282255710 m-v500"
+            className="jsx-2514143691 m-v500"
           >
             <div
-              className="jsx-4282255710 p-v200"
+              className="jsx-2514143691 p-v200"
             >
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   5
                    
@@ -10427,50 +10955,45 @@ exports[`Storyshots ReviewContent default 1`] = `
                   $14.00
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   $
                   70.00
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
-                <a
-                  className="jsx-4282255710"
-                  name="service-fee"
-                />
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="t--info"
                 >
                   Credit card service fee 
                   <a
-                    className="jsx-4282255710"
                     href="#service-fee"
                   >
                     *
                   </a>
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2394436591 cost"
                 >
                   $
                   1.76
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   Shipping within the U.S.
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   <i
-                    className="jsx-4282255710"
+                    className="jsx-2514143691"
                   >
                     included
                   </i>
@@ -10478,15 +11001,15 @@ exports[`Storyshots ReviewContent default 1`] = `
               </div>
             </div>
             <div
-              className="jsx-4282255710 cost-row"
+              className="jsx-2514143691 cost-row"
             >
               <span
-                className="jsx-4282255710 sh-title"
+                className="jsx-2514143691 sh-title"
               >
                 Total
               </span>
               <span
-                className="jsx-4282255710 cost br br-t100 p-v200"
+                className="jsx-2514143691 cost br br-t100 p-v200"
               >
                 $
                 71.76
@@ -10515,10 +11038,10 @@ exports[`Storyshots ReviewContent default 1`] = `
               className="jsx-2133745651"
               name="service-fee"
             />
-            * You are charged an extra service fee of 
-            $0.25
-             plus
+            * You are charged an extra service fee of not more than
              
+            $0.25
+             plus 
             2.15%
             . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
              
@@ -11249,16 +11772,16 @@ exports[`Storyshots ReviewContent submission error 1`] = `
           className="jsx-2133745651 p-a300"
         >
           <div
-            className="jsx-4282255710 m-v500"
+            className="jsx-2514143691 m-v500"
           >
             <div
-              className="jsx-4282255710 p-v200"
+              className="jsx-2514143691 p-v200"
             >
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   5
                    
@@ -11268,50 +11791,45 @@ exports[`Storyshots ReviewContent submission error 1`] = `
                   $14.00
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   $
                   70.00
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
-                <a
-                  className="jsx-4282255710"
-                  name="service-fee"
-                />
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="t--info"
                 >
                   Credit card service fee 
                   <a
-                    className="jsx-4282255710"
                     href="#service-fee"
                   >
                     *
                   </a>
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2394436591 cost"
                 >
                   $
                   1.76
                 </span>
               </div>
               <div
-                className="jsx-4282255710 cost-row"
+                className="jsx-2514143691 cost-row"
               >
                 <span
-                  className="jsx-4282255710 t--info"
+                  className="jsx-2514143691 t--info"
                 >
                   Shipping within the U.S.
                 </span>
                 <span
-                  className="jsx-4282255710 cost"
+                  className="jsx-2514143691 t--info cost"
                 >
                   <i
-                    className="jsx-4282255710"
+                    className="jsx-2514143691"
                   >
                     included
                   </i>
@@ -11319,15 +11837,15 @@ exports[`Storyshots ReviewContent submission error 1`] = `
               </div>
             </div>
             <div
-              className="jsx-4282255710 cost-row"
+              className="jsx-2514143691 cost-row"
             >
               <span
-                className="jsx-4282255710 sh-title"
+                className="jsx-2514143691 sh-title"
               >
                 Total
               </span>
               <span
-                className="jsx-4282255710 cost br br-t100 p-v200"
+                className="jsx-2514143691 cost br br-t100 p-v200"
               >
                 $
                 71.76
@@ -11356,10 +11874,10 @@ exports[`Storyshots ReviewContent submission error 1`] = `
               className="jsx-2133745651"
               name="service-fee"
             />
-            * You are charged an extra service fee of 
-            $0.25
-             plus
+            * You are charged an extra service fee of not more than
              
+            $0.25
+             plus 
             2.15%
             . This fee goes directly to a third party to pay for the cost of credit card processing. Learn more about
              
@@ -13564,8 +14082,10 @@ exports[`Storyshots ShippingContent default 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -14318,8 +14838,10 @@ exports[`Storyshots ShippingContent email error 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>
@@ -15077,8 +15599,10 @@ exports[`Storyshots ShippingContent existing address 1`] = `
                ×
                
               $14.00
-               + service fee = $
-              71.76
+               = $
+              70.00
+               
+              + service fee*
             </div>
           </div>
         </button>


### PR DESCRIPTION
Calculates the fee separately based on the card tokenization. Has to add
token lookup on the server side as well.

Adds "credit / debit" dropdown in order details.

Updates language to put credit card fees as a maximum amount, rather
than the exact amount.