### PR TITLE
Removes logging around order procedure calls

### DIFF
--- a/server/graphql/mutation.js
+++ b/server/graphql/mutation.js
@@ -152,7 +152,7 @@ export const resolvers = {
         .toString(36)
         .substr(2, 5);
 
-      const orderId = `DC-${datePart}-${randomPart}`;
+      const orderId = `REG-DC-${datePart}-${randomPart}`;
 
       const orderKey = await registryOrders.addOrder({
         orderID: orderId,

--- a/server/services/RegistryOrders.js
+++ b/server/services/RegistryOrders.js
@@ -102,7 +102,6 @@ export default class RegistryOrders {
 
       const { recordset } = resp;
 
-      console.log('RESPONSE FROM AddOrder', JSON.stringify(resp));
       if (!recordset || recordset.length === 0) {
         throw new Error('Recordset for creating an order came back empty');
       }
@@ -132,13 +131,6 @@ export default class RegistryOrders {
       this.opbeat &&
       this.opbeat.startTransaction('AddOrderItem', 'Registry Orders');
 
-    console.log(
-      orderKey,
-      certificateId,
-      certificateName,
-      quantity,
-      certificateCost
-    );
     try {
       const resp: DbResponse<Object> = (await this.pool
         .request()
@@ -150,11 +142,12 @@ export default class RegistryOrders {
         .input('unitCost', `$${certificateCost.toFixed(2)}`)
         .execute('Commerce.sp_AddOrderItem'): any);
 
-      console.log('RESPONSE FROM AddOrderItem', JSON.stringify(resp));
       const { recordset } = resp;
 
       if (!recordset || recordset.length === 0) {
-        throw new Error('Recordset for adding order item came back empty');
+        throw new Error(
+          `Could not add item to order ${orderKey}. Likely no certificate ID ${certificateId} in the database.`
+        );
       }
     } finally {
       if (transaction) {
@@ -183,7 +176,6 @@ export default class RegistryOrders {
         .input('paymentAmount', `$${totalInDollars.toFixed(2)}`)
         .execute('Commerce.sp_AddPayment'): any);
 
-      console.log('RESPONSE FROM AddPayment', JSON.stringify(resp));
       const { recordset } = resp;
 
       if (!recordset || recordset.length === 0) {


### PR DESCRIPTION
Dev database does not have recent certificates. Updates error message.
For testing, use older certificates.