### PR TITLE
Moves emailing and paid orders to a webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8-alpine
 WORKDIR /app
 
 # Install the AWS CLI
-RUN apk add --update python python-dev curl unzip \
+RUN apk add --update python python-dev curl unzip git \
   && cd /tmp \
   && curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" \
   && unzip awscli-bundle.zip \

--- a/fixtures/stripe/charge-succeeded.json
+++ b/fixtures/stripe/charge-succeeded.json
@@ -1,0 +1,96 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "charge.succeeded",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2017-08-15",
+  "data": {
+    "object": {
+      "id": "ch_00000000000000",
+      "object": "charge",
+      "amount": 1456,
+      "amount_refunded": 0,
+      "application": null,
+      "application_fee": null,
+      "balance_transaction": "txn_00000000000000",
+      "captured": true,
+      "created": 1513193222,
+      "currency": "usd",
+      "customer": null,
+      "description": "Death certificates (Registry)",
+      "destination": null,
+      "dispute": null,
+      "failure_code": null,
+      "failure_message": null,
+      "fraud_details": {
+      },
+      "invoice": null,
+      "livemode": false,
+      "metadata": {
+        "webapp.name": "registry-certs",
+        "webapp.nodeEnv": "test",
+        "order.orderId": "DC-20171215-yg4lk",
+        "order.orderKey": "19",
+        "order.quantity": "1",
+        "order.unitPrice": "1400"
+      },
+      "on_behalf_of": null,
+      "order": null,
+      "outcome": {
+        "network_status": "approved_by_network",
+        "reason": null,
+        "risk_level": "normal",
+        "seller_message": "Payment complete.",
+        "type": "authorized"
+      },
+      "paid": true,
+      "receipt_email": null,
+      "receipt_number": null,
+      "refunded": false,
+      "refunds": {
+        "object": "list",
+        "data": [
+
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges/ch_1BYfsgHEIqCf0Nlg2OMEEkQv/refunds"
+      },
+      "review": null,
+      "shipping": null,
+      "source": {
+        "id": "card_00000000000000",
+        "object": "card",
+        "address_city": "Boston",
+        "address_country": "us",
+        "address_line1": "1 City Hall Plaza",
+        "address_line1_check": "pass",
+        "address_line2": "",
+        "address_state": "MA",
+        "address_zip": "02141",
+        "address_zip_check": "pass",
+        "brand": "Visa",
+        "country": "US",
+        "customer": null,
+        "cvc_check": "pass",
+        "dynamic_last4": null,
+        "exp_month": 8,
+        "exp_year": 2019,
+        "fingerprint": "7BOjpkAVCEV1R04w",
+        "funding": "credit",
+        "last4": "4242",
+        "metadata": {
+        },
+        "name": "Tomas Lara-Perez",
+        "tokenization_method": null
+      },
+      "source_transfer": null,
+      "statement_descriptor": null,
+      "status": "succeeded",
+      "transfer_group": null
+    }
+  }
+}

--- a/flow-typed/npm/stripe_vx.x.x.js
+++ b/flow-typed/npm/stripe_vx.x.x.js
@@ -355,6 +355,14 @@ declare module 'stripe' {
   declare export type NodeStripe = {|
     setTimeout(ms: number): void,
     setHttpAgent(agent: Agent): void,
+
+    webhooks: {|
+      constructEvent(
+        payload: string,
+        header: string,
+        secret: string,
+        tolerance?: number): Event,
+    |},
     
     balance: {|
       retrieveTransaction(

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -948,6 +948,17 @@
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
+        "shelljs": {
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+          "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.1",
+            "interpret": "1.0.3",
+            "rechoir": "0.6.2"
+          }
+        },
         "sntp": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
@@ -1235,6 +1246,12 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
+      }
+    },
+    "address-rfc2822": {
+      "version": "github:CityOfBoston/node-address-rfc2822#06b86c8fa7f5d3c655c18b84dad7d23045d16dae",
+      "requires": {
+        "email-addresses": "3.0.1"
       }
     },
     "after-all-results": {
@@ -6073,6 +6090,11 @@
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
+    },
+    "email-addresses": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.1.tgz",
+      "integrity": "sha1-wfwgwYnn+W1AEtN121/qzN0kORw="
     },
     "emitter-mixin": {
       "version": "0.0.3",
@@ -13337,6 +13359,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
+    "moment-timezone": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
+      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "requires": {
+        "moment": "2.20.1"
+      }
+    },
     "ms": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -17606,9 +17636,9 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
+      "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
       "dev": true,
       "requires": {
         "glob": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "gulp build",
     "start": "node build/server",
     "storybook": "start-storybook -p 9001 -s static -c storybook",
-    "snapshot": "build-storybook -s static -c storybook && percy-storybook --widths=320,840,1280",
+    "snapshot": "babel-node ./scripts/snapshot",
     "lint": "eslint --fix .",
     "clear-babel-cache": "rm -rf node_modules/.cache/babel-loader",
     "generate-fixtures": "babel-node ./scripts/generate-fixtures",
@@ -51,6 +51,7 @@
     ]
   },
   "dependencies": {
+    "address-rfc2822": "github:CityOfBoston/node-address-rfc2822",
     "apollo-server-hapi": "^1.2.0",
     "aws-sdk": "^2.100.0",
     "babel-runtime": "^6.26.0",
@@ -74,6 +75,7 @@
     "mobx": "^3.3.0",
     "mobx-react": "^4.3.2",
     "moment": "^2.20.1",
+    "moment-timezone": "^0.5.14",
     "mssql": "^4.0.4",
     "next": "^4.2.3",
     "node-cleanup": "^2.1.2",
@@ -133,6 +135,7 @@
     "prettier": "^1.7.0",
     "prop-types": "^15.5.10",
     "react-test-renderer": "^16.0.0",
+    "shelljs": "^0.8.1",
     "through2": "^2.0.3",
     "webpack-bundle-analyzer": "^2.8.1"
   }

--- a/scripts/snapshot.js
+++ b/scripts/snapshot.js
@@ -1,0 +1,28 @@
+/* eslint no-console: 0 */
+
+// Runs the Storybook snapshot and sends the results to Percy.
+//
+// Only runs in Travis cases we care about so we don't send too much to Percy.
+
+import shell from 'shelljs';
+
+if (
+  (process.env['TRAVIS_PULL_REQUEST'] &&
+    process.env['TRAVIS_PULL_REQUEST'] !== 'false') ||
+  process.env['TRAVIS_BRANCH'] === 'production'
+) {
+  if (shell.exec('build-storybook -s static -c storybook').code !== 0) {
+    shell.echo('Error: build-storybook failed');
+    shell.exit(1);
+  }
+
+  if (shell.exec('percy-storybook --widths=320,840,1280').code !== 0) {
+    shell.echo('Error: percy-storybook failed');
+    shell.exit(1);
+  }
+} else {
+  console.log(
+    `Not running snapshot.js because there’s no pull request and the branch (${process
+      .env['TRAVIS_BRANCH']}) is not “production”.`
+  );
+}

--- a/server/email/ReceiptEmail.js
+++ b/server/email/ReceiptEmail.js
@@ -9,7 +9,8 @@ import mjml2html from 'mjml';
 require('./handlebars-helpers');
 
 export type TemplateData = {
-  orderDate: Date,
+  // already-formatted date
+  orderDate: string,
   orderId: string,
   shippingName: string,
   shippingCompanyName: string,
@@ -18,6 +19,7 @@ export type TemplateData = {
   shippingCity: string,
   shippingState: string,
   shippingZip: string,
+  // all these costs are in cents, matching Stripe
   subtotal: number,
   serviceFee: number,
   total: number,

--- a/server/email/ReceiptEmail.test.js
+++ b/server/email/ReceiptEmail.test.js
@@ -4,7 +4,7 @@ import ReceiptEmail from './ReceiptEmail';
 import { SERVICE_FEE_URI } from '../../lib/costs';
 
 const TEST_ORDER = {
-  orderDate: new Date(1515438318 * 1000),
+  orderDate: '1/8/2018 2:05PM',
   orderId: 'RG-DC201801-100001',
   shippingName: 'Nancy Whitehead',
   shippingCompanyName: '',

--- a/server/email/receipt.mjml.hbs
+++ b/server/email/receipt.mjml.hbs
@@ -29,7 +29,7 @@
         <mj-section padding="10px 0">
           <mj-column vertical-align="top">
             <mj-text>
-              <b>Date:</b> <i>{{formatDate orderDate}}</i><br/>
+              <b>Date:</b> <i>{{orderDate}}</i><br/>
               <b>Order #:</b> <i>{{orderId}}</i>
             </mj-text>
           </mj-column>

--- a/server/email/receipt.txt.hbs
+++ b/server/email/receipt.txt.hbs
@@ -3,7 +3,7 @@ City of Boston
 Thank you for your order!
 
 {{#with order}}
-Date: {{formatDate orderDate}}
+Date: {{orderDate}}
 Order ID: {{orderId}}
 
 Your shipping information:

--- a/server/graphql/mutation.test.js
+++ b/server/graphql/mutation.test.js
@@ -107,6 +107,8 @@ describe('Mutation resolvers', () => {
         description: 'Death certificates (Registry)',
         statement_descriptor: 'CITYBOSTON*REG + FEE',
         metadata: expect.objectContaining({
+          'webapp.name': 'registry-certs',
+          'webapp.nodeEnv': 'test',
           'order.orderId': expect.any(String),
           'order.orderKey': '25',
           'order.quantity': '10',

--- a/server/services/Emails.js
+++ b/server/services/Emails.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { Client as PostmarkClient } from 'postmark';
+import { Address } from 'address-rfc2822';
 
 import ReceiptEmail, {
   type TemplateData as ReceiptTemplateData,
@@ -23,12 +24,20 @@ export default class Emails {
     this.receiptEmail = new ReceiptEmail();
   }
 
-  async sendReceiptEmail(to: string, data: ReceiptTemplateData): Promise<void> {
+  formatTo(toName: string, toEmail: string): string {
+    return new Address(toName, toEmail).format();
+  }
+
+  async sendReceiptEmail(
+    toName: string,
+    toEmail: string,
+    data: ReceiptTemplateData
+  ): Promise<void> {
     try {
       await new Promise((resolve, reject) =>
         this.postmarkClient.sendEmail(
           {
-            To: to,
+            To: this.formatTo(toName, toEmail),
             From: this.from,
             Subject: `City of Boston Death Certificates Order #${data.orderId}`,
             HtmlBody: this.receiptEmail.renderHtmlBody(data),

--- a/server/services/Emails.test.js
+++ b/server/services/Emails.test.js
@@ -1,0 +1,38 @@
+// @flow
+
+import Emails from './Emails';
+
+describe('formatTo', () => {
+  let emails: Emails;
+
+  beforeEach(() => {
+    emails = new Emails('test@boston.gov', ({}: any), ({}: any));
+  });
+
+  it('formats when no name', () => {
+    expect(emails.formatTo('', 'nancy@mew.org')).toEqual('nancy@mew.org');
+  });
+
+  it('formats with name and no comma', () => {
+    expect(emails.formatTo('Nancy Whitehead', 'nancy@mew.org')).toEqual(
+      'Nancy Whitehead <nancy@mew.org>'
+    );
+  });
+
+  it('formats with name with accent', () => {
+    expect(
+      emails.formatTo(
+        'María Aracely Josefina Penalba de las Heras',
+        'hummingbird@newwarriors.org'
+      )
+    ).toEqual(
+      '"María Aracely Josefina Penalba de las Heras" <hummingbird@newwarriors.org>'
+    );
+  });
+
+  it('formats with name with comma', () => {
+    expect(
+      emails.formatTo('Jennifer Walters, Esq.', 'jwalters@walterslaw.com')
+    ).toEqual('"Jennifer Walters, Esq." <jwalters@walterslaw.com>');
+  });
+});

--- a/server/stripe-events.js
+++ b/server/stripe-events.js
@@ -1,0 +1,153 @@
+// @flow
+/* eslint no-console: 0 */
+import type RegistryData from './services/RegistryData';
+import type RegistryOrders from './services/RegistryOrders';
+import type Emails from './services/Emails';
+import type { NodeStripe, Event, Charge } from 'stripe';
+
+import { loadOrder } from './graphql/death-certificates';
+
+import {
+  FIXED_CC_SERVICE_FEE,
+  PERCENTAGE_CC_SERVICE_FEE,
+  SERVICE_FEE_URI,
+} from '../lib/costs';
+
+type Opbeat = $Exports<'opbeat'>;
+
+type Dependencies = {|
+  opbeat: Opbeat,
+  emails: Emails,
+  stripe: NodeStripe,
+  registryData: RegistryData,
+  registryOrders: RegistryOrders,
+|};
+
+// We handle Stripe’s "charge.succeeded" event to complete the order process:
+//   - Mark the order as "paid" in the backend so that fulfillment can complete
+//   - Send a receipt email
+//
+// We do this from Stripe’s webhook to take advantage of their reliability
+// features. If the charge succeeded, THE ORDER MUST BE PLACED for the customer.
+// If we tried to do this inline in the mutation after the charge API call,
+// there’s a chance that the database write would fail, or the email wouldn’t
+// send.
+//
+// If those things happen in this case, we’ll send a 500 back to Stripe and it
+// will retry. If it keeps failing, Stripe will notify us of the issue.
+//
+// Note that there is a non-zero chance that Stripe will call this twice for the
+// same charge, meaning we will send 2 emails to the customer about the order.
+// That’s a better choice than not sending an email at all or causing delays in
+// fulfillment, so we can live with it.
+export async function processChargeSucceeded(
+  { emails, registryData, registryOrders }: Dependencies,
+  charge: Charge
+) {
+  const {
+    metadata: {
+      'webapp.name': webappName,
+      'webapp.nodeEnv': webappNodeEnv,
+      'order.orderKey': orderKey,
+      'order.orderId': orderId,
+    },
+  } = charge;
+
+  // We're going to get every Stripe event, so make sure that we’e only handling
+  // our own. Also, we do the NODE_ENV check so that charges made in dev (which
+  // still go to Test Stripe) don’t cause staging to send an email.
+  if (
+    webappName !== 'registry-certs' ||
+    webappNodeEnv !== process.env.NODE_ENV
+  ) {
+    return;
+  }
+
+  // We slightly-hackily rely on the DB order -> JS object code from the GraphQL
+  // side of things. This could be more principled.
+  const order = await loadOrder(registryData, registryOrders, orderId);
+
+  if (!order) {
+    throw new Error(`Order ${orderId} not found in the database`);
+  }
+
+  // By marking the payment as successful we can tell Registry they can proceed
+  // with fulfillment. This method is idempotent.
+  await registryOrders.addPayment(
+    parseInt(orderKey, 10),
+    // Unix epoch seconds -> milliseconds
+    new Date(charge.created * 1000),
+    charge.id,
+    // Per Rich, this should be the total amount charged by Stripe, including
+    // their fee, not just the subtotal we receive.
+    charge.amount / 100
+  );
+
+  // Sending the email is not idempotent, so we put it last and in the vast
+  // majority of cases it will run once.
+  await emails.sendReceiptEmail(order.contactName, order.contactEmail, {
+    orderId: order.id,
+    orderDate: order.date,
+    shippingName: order.shippingName,
+    shippingCompanyName: order.shippingCompanyName,
+    shippingAddress1: order.shippingAddress1,
+    shippingAddress2: order.shippingAddress2,
+    shippingCity: order.shippingCity,
+    shippingState: order.shippingState,
+    shippingZip: order.shippingZip,
+    subtotal: order.subtotal,
+    serviceFee: order.serviceFee,
+    total: order.total,
+    fixedFee: FIXED_CC_SERVICE_FEE,
+    percentageFee: PERCENTAGE_CC_SERVICE_FEE,
+    serviceFeeUri: SERVICE_FEE_URI,
+    // loadOrder comes from the GraphQL side of things first and foremost, so it
+    // returns an async function for the certificate so that the extra DB lookup
+    // (needed for certificate name) doesn’t have to happen if it’s not
+    // requested by the query. Since we do need the name for the receipt, we
+    // have to trigger and then resolve the promises.
+    items: await Promise.all(
+      order.items.map(async ({ id, quantity, cost, certificate }) => ({
+        id,
+        quantity,
+        cost,
+        name: nameFromCertificate(await certificate()),
+      }))
+    ),
+  });
+}
+
+function nameFromCertificate(cert) {
+  if (cert) {
+    return `${cert.firstName} ${cert.lastName}`;
+  } else {
+    // typically should not happen, but we need to guard anyway
+    return 'UNKNOWN CERTIFICATE';
+  }
+}
+
+export async function processStripeEvent(
+  deps: Dependencies,
+  webhookSecret: ?string,
+  webhookSignature: string,
+  body: string
+): Promise<void> {
+  const event: Event = webhookSecret
+    ? deps.stripe.webhooks.constructEvent(body, webhookSignature, webhookSecret)
+    : JSON.parse(body);
+
+  if (process.env['NODE_ENV'] !== 'test') {
+    console.log(
+      'STRIPE WEBHOOK: ',
+      JSON.stringify({ ...event, data: 'REDACTED' })
+    );
+  }
+
+  switch (event.type) {
+    case 'charge.succeeded':
+      await processChargeSucceeded(deps, event.data.object);
+      break;
+    default:
+      break;
+  }
+}

--- a/server/stripe-events.test.js
+++ b/server/stripe-events.test.js
@@ -1,0 +1,77 @@
+// @flow
+
+import { processStripeEvent } from './stripe-events';
+
+import type RegistryData from './services/RegistryData';
+import type RegistryOrders from './services/RegistryOrders';
+
+import CHARGE_SUCCEEDED from '../fixtures/stripe/charge-succeeded';
+import ORDER from '../fixtures/registry-orders/order.json';
+import CERTIFICATES from '../fixtures/registry-data/smith.json';
+
+describe('charge.created', () => {
+  let opbeat;
+  let emails;
+  let stripe;
+  let registryData: RegistryData;
+  let registryOrders: RegistryOrders;
+
+  beforeEach(() => {
+    opbeat = ({}: any);
+    emails = ({
+      sendReceiptEmail: jest.fn(),
+    }: any);
+    stripe = ({}: any);
+    registryData = ({
+      lookup: () => CERTIFICATES[0],
+    }: any);
+    registryOrders = ({
+      findOrder: () => ORDER,
+      addPayment: jest.fn(),
+    }: any);
+  });
+
+  it('marks the order as paid', async () => {
+    await processStripeEvent(
+      {
+        opbeat,
+        emails,
+        stripe,
+        registryData,
+        registryOrders,
+      },
+      null,
+      '',
+      JSON.stringify(CHARGE_SUCCEEDED)
+    );
+
+    expect(registryOrders.addPayment).toHaveBeenCalledWith(
+      19, // the order key from the charge as an int
+      expect.anything(),
+      expect.anything(),
+      14.56 // the charge amount in a float, rather than Stripe's cents
+    );
+  });
+
+  it('sends email', async () => {
+    await processStripeEvent(
+      {
+        opbeat,
+        emails,
+        stripe,
+        registryData,
+        registryOrders,
+      },
+      null,
+      '',
+      JSON.stringify(CHARGE_SUCCEEDED)
+    );
+
+    expect(emails.sendReceiptEmail).toHaveBeenCalledWith(
+      'Nancy Whitehead',
+      'nancy@mew.org',
+      // we're letting the type checking ensure that all this data is complete.
+      expect.anything()
+    );
+  });
+});


### PR DESCRIPTION
Implements #269

Also includes improvement to email name formatting and prevents Percy
from running on anything other than a PR and the production branch, so
we don't waste snapshots on Greenkeeper or staging.